### PR TITLE
Add API key auth with request tracking and dashboard

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,9 +1,12 @@
-import { readDB, writeDB } from '../../lib/db.js'
+import { readDB } from '../../lib/db.js'
+import bcrypt from 'bcrypt'
 
-export default function handler(req, res) {
-  const { username } = req.body
+export default async function handler(req, res) {
+  const { username, password } = req.body
   const db = readDB()
   const user = Object.values(db.users).find(u => u.username === username)
   if (!user) return res.status(404).json({ error: 'Usuario no encontrado' })
+  const ok = await bcrypt.compare(password, user.password)
+  if (!ok) return res.status(401).json({ error: 'Contraseña incorrecta' })
   res.json({ key: user.key })
 }

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,12 +1,15 @@
 import { readDB, writeDB } from '../../lib/db.js'
 import crypto from 'crypto'
+import bcrypt from 'bcrypt'
 
-export default function handler(req, res) {
-  const { username } = req.body
+export default async function handler(req, res) {
+  const { username, password } = req.body
+  if (!username || !password) return res.status(400).json({ error: 'Faltan datos' })
   const db = readDB()
   const id = crypto.randomUUID()
-  const key = crypto.randomBytes(16).toString('hex')
-  db.users[id] = { id, username, key }
+  const key = `Adonixv2-${Math.floor(10000 + Math.random() * 90000)}`
+  const hashed = await bcrypt.hash(password, 10)
+  db.users[id] = { id, username, password: hashed, key }
   writeDB(db)
   res.json({ success: true, key })
 }

--- a/api/dashboard.js
+++ b/api/dashboard.js
@@ -1,0 +1,12 @@
+import verifyKey from '../utils/verifyKey.js'
+import { readDB } from '../lib/db.js'
+
+export default function handler(req, res) {
+  verifyKey(req, res, () => {
+    const db = readDB()
+    const today = new Date().toISOString().slice(0, 10)
+    const todayCount = db.usage[today]?.[req.user.id] || 0
+    const total = Object.values(db.usage).reduce((sum, day) => sum + (day[req.user.id] || 0), 0)
+    res.json({ requestsToday: todayCount, requestsTotal: total })
+  })
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 import express from 'express'
+import path from 'path'
+import { fileURLToPath } from 'url'
 import register from './api/auth/register.js'
 import login from './api/auth/login.js'
 import endpoint1 from './api/endpoint1.js'
@@ -7,6 +9,11 @@ import dashboard from './api/dashboard.js'
 
 const app = express()
 app.use(express.json())
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+app.get('/dashboard', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'dashboard.html'))
+})
 
 app.post('/api/auth/register', register)
 app.post('/api/auth/login', login)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import register from './api/auth/register.js'
 import login from './api/auth/login.js'
 import endpoint1 from './api/endpoint1.js'
 import endpoint2 from './api/endpoint2.js'
+import dashboard from './api/dashboard.js'
 
 const app = express()
 app.use(express.json())
@@ -11,6 +12,7 @@ app.post('/api/auth/register', register)
 app.post('/api/auth/login', login)
 app.get('/api/endpoint1', endpoint1)
 app.get('/api/endpoint2', endpoint2)
+app.get('/api/dashboard', dashboard)
 
 const PORT = process.env.PORT || 3000
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`))

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8" />
+<title>Dashboard</title>
+</head>
+<body>
+<h1>Dashboard</h1>
+<section>
+<h2>Registrarse</h2>
+<input id="reg-username" placeholder="Usuario" />
+<input id="reg-password" type="password" placeholder="Contraseña" />
+<button onclick="register()">Enviar</button>
+<pre id="reg-result"></pre>
+</section>
+<section>
+<h2>Iniciar sesión</h2>
+<input id="log-username" placeholder="Usuario" />
+<input id="log-password" type="password" placeholder="Contraseña" />
+<button onclick="login()">Enviar</button>
+<pre id="log-result"></pre>
+</section>
+<section>
+<h2>Endpoint 1</h2>
+<input id="ep1-key" placeholder="API Key" />
+<button onclick="ep1()">Probar</button>
+<pre id="ep1-result"></pre>
+</section>
+<section>
+<h2>Endpoint 2</h2>
+<input id="ep2-key" placeholder="API Key" />
+<button onclick="ep2()">Probar</button>
+<pre id="ep2-result"></pre>
+</section>
+<section>
+<h2>Dashboard API</h2>
+<input id="dash-key" placeholder="API Key" />
+<button onclick="dash()">Ver</button>
+<pre id="dash-result"></pre>
+</section>
+<script>
+async function register(){
+ const res=await fetch('/api/auth/register',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:document.getElementById('reg-username').value,password:document.getElementById('reg-password').value})});
+ document.getElementById('reg-result').textContent=JSON.stringify(await res.json(),null,2);
+}
+async function login(){
+ const res=await fetch('/api/auth/login',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({username:document.getElementById('log-username').value,password:document.getElementById('log-password').value})});
+ document.getElementById('log-result').textContent=JSON.stringify(await res.json(),null,2);
+}
+async function ep1(){
+ const res=await fetch('/api/endpoint1',{headers:{'x-api-key':document.getElementById('ep1-key').value}});
+ document.getElementById('ep1-result').textContent=JSON.stringify(await res.json(),null,2);
+}
+async function ep2(){
+ const res=await fetch('/api/endpoint2',{headers:{'x-api-key':document.getElementById('ep2-key').value}});
+ document.getElementById('ep2-result').textContent=JSON.stringify(await res.json(),null,2);
+}
+async function dash(){
+ const res=await fetch('/api/dashboard',{headers:{'x-api-key':document.getElementById('dash-key').value}});
+ document.getElementById('dash-result').textContent=JSON.stringify(await res.json(),null,2);
+}
+</script>
+</body>
+</html>

--- a/utils/verifyKey.js
+++ b/utils/verifyKey.js
@@ -12,7 +12,7 @@ export default function verifyKey(req, res, next) {
   db.usage[today] = db.usage[today] || {}
   db.usage[today][user.id] = (db.usage[today][user.id] || 0) + 1
 
-  if (db.usage[today][user.id] > 100) return res.status(429).json({ error: 'Límite diario alcanzado' })
+  if (db.usage[today][user.id] > 2000) return res.status(429).json({ error: 'Límite diario alcanzado' })
 
   writeDB(db)
   req.user = user


### PR DESCRIPTION
## Summary
- require password on registration with hashed storage and Adonixv2-style API key generation
- add password-based login and daily API key limit of 2000 requests
- provide dashboard endpoint to show per-user request counts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688fcba6856c83268020d121f4e3a31b